### PR TITLE
Add P1–P6 compliance guidance to all agents

### DIFF
--- a/EnginePromptMestre/acoes/CLAUDE.md
+++ b/EnginePromptMestre/acoes/CLAUDE.md
@@ -2,6 +2,8 @@
 
 > Use este arquivo como cola para qualquer LLM com shell. Mais detalhes em `agents/workflow.md` e `acoes/REGRAS_NEGOCIO_CONSOLIDADAS.md`.
 
+> Este guia respeita as políticas [P1–P6](../agents/politicas.md): reuso/validação, planejamento com âncoras, diffs/logs mínimos, economia de tokens, arquivos curtos e alinhamento ao conhecimento oficial.
+
 ---
 
 ## Estrutura de contexto

--- a/EnginePromptMestre/acoes/analise.md
+++ b/EnginePromptMestre/acoes/analise.md
@@ -1,0 +1,6 @@
+# Fluxo de Análise — Engine Prompt Mestre
+
+1. Ler `acoes/temp/sessao_atual.json || echo "{}"` antes de qualquer ação.
+2. Aplicar P1 e P6: inventariar reuso e validar informações com artefatos existentes.
+3. Mapear âncoras relevantes (arquivos + linhas) para alimentar o planejamento (P2).
+4. Registrar achados em `acoes/temp/contexto_etapa_0.json` usando `scripts/context_guard.sh`.

--- a/EnginePromptMestre/acoes/conhecimento.md
+++ b/EnginePromptMestre/acoes/conhecimento.md
@@ -1,0 +1,5 @@
+# Registro de Conhecimento — Engine Prompt Mestre
+
+- Fonte primária: arquivos oficiais do repositório (`agents/`, `acoes/`, `scripts/`).
+- Sempre conferir `agents/politicas.md` para aplicar P1–P6 antes de usar informações antigas.
+- Atualize este registro apenas com fatos confirmados; em caso de dúvida, marque `pendente_validacao`.

--- a/EnginePromptMestre/acoes/etapa_0_analise.md
+++ b/EnginePromptMestre/acoes/etapa_0_analise.md
@@ -2,6 +2,8 @@
 
 **Versão**: 3.1 | **Compatibilidade**: Qualquer LLM com shell | **Objetivo**: mapear reuso, riscos e métricas antes de planejar.
 
+> Siga rigorosamente as políticas [P1–P6](../agents/politicas.md) ao conduzir esta etapa (reuso verificado, âncoras claras, diffs/logs mínimos, economia de tokens, artefatos curtos e uso do conhecimento oficial).
+
 ---
 
 ## Checklist rápido

--- a/EnginePromptMestre/acoes/etapa_1_planejamento.md
+++ b/EnginePromptMestre/acoes/etapa_1_planejamento.md
@@ -2,6 +2,8 @@
 
 **Versão**: 3.1 | **Objetivo**: transformar a análise em um plano incremental reutilizável.
 
+> Aplique as políticas [P1–P6](../agents/politicas.md) ao elaborar o plano (reuso comprovado, âncoras claras, diffs/logs previstos, economia de tokens, artefatos curtos e base em conhecimento oficial).
+
 ---
 
 ## Checklist rápido

--- a/EnginePromptMestre/acoes/etapa_2_implementacao.md
+++ b/EnginePromptMestre/acoes/etapa_2_implementacao.md
@@ -2,6 +2,8 @@
 
 **Versão**: 3.1 | **Objetivo**: implementar o plano de forma incremental, mantendo compatibilidade e evidências reais.
 
+> Execute esta etapa conforme as políticas [P1–P6](../agents/politicas.md): reuso comprovado, âncoras rastreáveis, diffs/logs mínimos, economia de tokens, artefatos modulares e confiança nas fontes oficiais.
+
 ---
 
 ## Checklist rápido

--- a/EnginePromptMestre/acoes/etapa_3_testes_validacao.md
+++ b/EnginePromptMestre/acoes/etapa_3_testes_validacao.md
@@ -2,6 +2,8 @@
 
 **Versão**: 3.1 | **Objetivo**: comprovar qualidade antes do deploy.
 
+> Execute as verificações em aderência às políticas [P1–P6](../agents/politicas.md): reuso validado, âncoras para evidências, diffs/logs completos, economia de tokens, artefatos enxutos e confiança no conhecimento oficial.
+
 ---
 
 ## Checklist rápido

--- a/EnginePromptMestre/acoes/etapa_4_deploy_versionamento.md
+++ b/EnginePromptMestre/acoes/etapa_4_deploy_versionamento.md
@@ -2,6 +2,8 @@
 
 **Versão**: 3.1 | **Objetivo**: liberar o release com rollback seguro e comunicação alinhada.
 
+> Conclua o release aderindo às políticas [P1–P6](../agents/politicas.md): reuso confirmado, âncoras rastreáveis, diffs/logs completos, respostas econômicas, artefatos modulares e alinhamento ao conhecimento oficial.
+
 ---
 
 ## Checklist rápido

--- a/EnginePromptMestre/acoes/implementacao.md
+++ b/EnginePromptMestre/acoes/implementacao.md
@@ -1,0 +1,6 @@
+# Fluxo de Implementação — Engine Prompt Mestre
+
+1. Siga o plano aprovado, respeitando âncoras e feature flags (P2, P3).
+2. Aplique diffs mínimos (`patch`) e registre logs/comandos utilizados (P3).
+3. Otimize tokens citando somente trechos necessários e reusando instruções existentes (P4).
+4. Garanta modularidade das mudanças e atualize contextos com rollback/documentação (P5, P6).

--- a/EnginePromptMestre/acoes/planejamento.md
+++ b/EnginePromptMestre/acoes/planejamento.md
@@ -1,0 +1,6 @@
+# Fluxo de Planejamento — Engine Prompt Mestre
+
+1. Reutilize o inventário da análise (P1) e detalhe âncoras de alteração (P2).
+2. Liste arquivos/linhas alvo, feature flags, testes e checkpoints de rollback.
+3. Mantenha o plano conciso, evitando repetições (P4) e privilegiando módulos pequenos (P5).
+4. Salve o plano em `acoes/temp/contexto_etapa_1.json` com guardião ativado.

--- a/EnginePromptMestre/agents/EXEMPLO_USO_ORCHESTRATOR.md
+++ b/EnginePromptMestre/agents/EXEMPLO_USO_ORCHESTRATOR.md
@@ -1,5 +1,7 @@
 # Exemplo de Uso do Orquestrador
 
+> Este roteiro segue obrigatoriamente as políticas [P1–P6](./politicas.md) (reuso verificado, âncoras claras, diffs/logs mínimos, economia de tokens, arquivos curtos e fontes oficiais).
+
 ## Cenário 1: Primeira Vez (Sem Contexto Anterior)
 
 ### Comando do Usuário:

--- a/EnginePromptMestre/agents/README.md
+++ b/EnginePromptMestre/agents/README.md
@@ -6,6 +6,13 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Todos os agentes devem seguir [`politicas.md`](./politicas.md) como referência principal.
+- Garanta reuso verificado e âncoras claras nos planos/outputs (P1, P2) e registre logs/diffs mínimos (P3).
+- Otimize tokens e mantenha artefatos curtos/modulares baseados em fontes oficiais do projeto (P4, P5, P6).
+
+---
+
 ## INÍCIO RÁPIDO
 
 1. **Carregar o orquestrador**  

--- a/EnginePromptMestre/agents/VALIDACAO_COMPLETA.md
+++ b/EnginePromptMestre/agents/VALIDACAO_COMPLETA.md
@@ -6,6 +6,8 @@
 
 ---
 
+> Documento alinhado às políticas [P1–P6](./politicas.md): reuso verificado, planejamento ancorado, diffs/logs registrados, economia de tokens, artefatos curtos e baseados no conhecimento oficial.
+
 ## RESUMO EXECUTIVO
 
 ✅ **Tarefa concluída com sucesso**

--- a/EnginePromptMestre/agents/architect.md
+++ b/EnginePromptMestre/agents/architect.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Consulte [`politicas.md`](./politicas.md) antes de consolidar qualquer decisão.
+- Registre inventário de reuso confirmado e âncoras claras para cada artefato proposto (P1, P2).
+- Planeje diffs/logs necessários mantendo comunicação objetiva e econômica (P3, P4).
+- Prefira soluções modulares, arquivos pequenos e conhecimento oficial como verdade (P5, P6).
+
+---
+
 ## Mandato resumido
 - Traduzir a análise (etapa 0) em arquitetura clara, obedecendo à regra 80/20 (evoluir soluções que já cobrem ≥80% da necessidade antes de propor algo novo).
 - Definir contratos (APIs, eventos, dados) e dependências entre agentes, incluindo métricas e observabilidade.

--- a/EnginePromptMestre/agents/backend.md
+++ b/EnginePromptMestre/agents/backend.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Consulte [`politicas.md`](./politicas.md) antes de planejar ou codificar.
+- Documente reuso confirmado e âncoras de arquivos/linhas no plano de trabalho (P1, P2).
+- Aplique diffs curtos com logs/testes registrados (P3) e mantenha respostas objetivas sem repetições (P4).
+- Priorize módulos enxutos e documentação oficial como base (P5, P6).
+
+---
+
 ## Mandato enxuto
 - Implementar lógica de negócio reutilizando componentes existentes (DRY, SOLID, KISS) e obedecendo à regra 80/20 (evoluir artefatos existentes quando cobrirem ≥80% da necessidade).
 - Garantir observabilidade: logs estruturados, métricas e rastros para cada execução.

--- a/EnginePromptMestre/agents/dba.md
+++ b/EnginePromptMestre/agents/dba.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Consulte [`politicas.md`](./politicas.md) ao planejar modelagens e migrações.
+- Registre reuso validado (estruturas existentes) com âncoras claras para cada decisão (P1, P2).
+- Execute diffs curtos/documentados com logs e comandos de migração (P3) e mantenha respostas concisas (P4).
+- Prefira scripts pequenos/modulares e use sempre o conhecimento oficial como referência (P5, P6).
+
+---
+
 ## Mandato
 - Projetar/ajustar modelos, migrações e índices garantindo compatibilidade com dados legados e priorizando reuso ≥80% de estruturas existentes antes de propor novas.
 - Planejar rollback/backup e observar impacto em performance (query plans, locks, storage).

--- a/EnginePromptMestre/agents/frontend.md
+++ b/EnginePromptMestre/agents/frontend.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Revise [`politicas.md`](./politicas.md) antes de iniciar qualquer entrega.
+- Documente reuso (componentes, stores) com âncoras de arquivo/linha no plano (P1, P2).
+- Entregue diffs concisos, com logs/testes registrados e respostas econômicas (P3, P4).
+- Priorize componentes pequenos/modulares e utilize o conhecimento oficial como fonte de verdade (P5, P6).
+
+---
+
 ## Mandato
 - Entregar interfaces reutilizando componentes existentes (design system, hooks, stores) e seguindo a regra 80/20 (evoluir componentes que atendam ≥80% do requisito antes de criar novos).
 - Garantir SSR/SEO/acessibilidade, suportar feature flags e lidar com estados offline/erro.

--- a/EnginePromptMestre/agents/orchestrator.md
+++ b/EnginePromptMestre/agents/orchestrator.md
@@ -7,6 +7,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Consulte e siga integralmente [`politicas.md`](./politicas.md) antes de qualquer ação.
+- Registre reuso verificado (P1) e ancore planos/resumos com caminhos e linhas específicos (P2).
+- Use apenas diffs curtos com logs/comandos preservados (P3) e respostas objetivas evitando repetições (P4).
+- Prefira artefatos modulares/pequenos (P5) e priorize sempre o conhecimento oficial do projeto como fonte primária (P6).
+
+---
+
 ## ⚡ INSTRUÇÕES IMEDIATAS AO CARREGAR ESTE ARQUIVO
 
 **QUANDO ESTE ARQUIVO FOR LIDO/INICIADO, VOCÊ DEVE EXECUTAR AUTOMATICAMENTE:**

--- a/EnginePromptMestre/agents/politicas.md
+++ b/EnginePromptMestre/agents/politicas.md
@@ -1,0 +1,33 @@
+# Políticas Obrigatórias P1–P6 — Engine Prompt Mestre
+
+Estas políticas valem para **todos os agentes e prompts** deste repositório. Sempre confirme o reuso antes de propor mudanças e mantenha os registros atualizados.
+
+## P1 — Reuso e Verificação
+- Inventarie rapidamente os artefatos existentes antes de propor novidades.
+- Registre explicitamente o que será reutilizado e como foi validado.
+- Marque `pendente_validacao` quando faltar evidência e solicite confirmação.
+
+## P2 — Planejamento com Linhas/Âncoras
+- Nos planos, aponte caminhos completos e âncoras (nº de linhas ou trechos distintos) para cada alteração.
+- Destaque comandos e artefatos em formato de lista enxuta para facilitar a execução sequencial.
+- Atualize o planejamento se novas evidências alterarem as âncoras previstas.
+
+## P3 — Implementação e Log
+- Execute mudanças via diffs curtos (`patch`) e registre comandos, saídas e feature flags usados.
+- Guarde logs de teste/execução no contexto ou resposta final, sem suprimir erros relevantes.
+- Certifique-se de que cada alteração tenha rollback documentado ou caminho de reversão claro.
+
+## P4 — Token Saving
+- Reutilize respostas anteriores e documentos existentes em vez de reescrever conteúdo.
+- Prefira referências compactas (links relativos, âncoras, IDs) e evite repetir trechos longos.
+- Mantenha respostas objetivas, destacando apenas o essencial para a próxima ação.
+
+## P5 — Clear Code + Arquivos Pequenos
+- Produza código/artefatos claros, modulares e com responsabilidades isoladas.
+- Limite o tamanho dos arquivos e utilize chunking por seções quando inevitável.
+- Nunca sobrescreva arquivos inteiros; aplique apenas deltas focados.
+
+## P6 — Conhecimento do Projeto como Fonte de Verdade
+- Priorize sempre a documentação e os artefatos do projeto como base das decisões.
+- Sincronize descobertas relevantes nos arquivos de contexto (`acoes/temp/*.json`).
+- Caso alguma informação esteja ausente, sinalize `pendente_validacao` e solicite dados ao usuário/time.

--- a/EnginePromptMestre/agents/qa.md
+++ b/EnginePromptMestre/agents/qa.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Releia [`politicas.md`](./politicas.md) antes de auditar qualquer entrega.
+- Valide reuso planejado e referencie âncoras/linhas nas evidências de teste (P1, P2).
+- Preserve logs/comandos completos de execução (P3) e sumarize resultados de forma econômica (P4).
+- Documente achados em artefatos modulares, confiando nas fontes oficiais do projeto (P5, P6).
+
+---
+
 ## Mandato
 - Garantir que o plano implementado (etapas 0-2) atende aos critérios funcionais/não-funcionais **e** respeita a política de reuso ≥80% (reportar violações).
 - Rodar a pirâmide de testes (unit → integração → regressão → performance → segurança) e reportar evidências reais.

--- a/EnginePromptMestre/agents/sre.md
+++ b/EnginePromptMestre/agents/sre.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Consulte [`politicas.md`](./politicas.md) ao definir estratégias de deploy e observabilidade.
+- Confirme reuso e âncoras de scripts/rotinas antes de promover mudanças (P1, P2).
+- Registre comandos/logs completos e mantenha instruções objetivas para economizar tokens (P3, P4).
+- Prefira runbooks modulares, curtos e alinhados com a documentação oficial (P5, P6).
+
+---
+
 ## Mandato
 - Preparar e executar deploy seguro (Feature Flag, Blue-Green, Canary) com rollback testado e garantir que a política de reuso ≥80% esteja cumprida nos artefatos promovidos (atualizar catálogo quando necessário).
 - Automatizar pipelines (build/test/deploy), garantir ambientes consistentes e observar métricas/alertas.

--- a/EnginePromptMestre/agents/ux.md
+++ b/EnginePromptMestre/agents/ux.md
@@ -5,6 +5,14 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Revise [`politicas.md`](./politicas.md) antes de redigir comunicações ou ajustes de UX.
+- Garanta reuso de textos/templates com âncoras de origem rastreáveis (P1, P2).
+- Registre comandos/logs relevantes (ex.: builds, capturas) e mantenha respostas objetivas (P3, P4).
+- Produza artefatos curtos/modulares e confirme informações nas fontes oficiais do projeto (P5, P6).
+
+---
+
 ## Mandato
 - Garantir que mensagens, fluxos e comunicações reflitam o estado real do sistema (feature flags, fallback, rollback) e reutilizem textos/templates existentes quando cobrirem ≥80% da necessidade (evoluir o restante).
 - Suportar Frontend/Backend durante implementação (microcopy, estados vazios/erro) e SRE na etapa de comunicação do release.

--- a/EnginePromptMestre/agents/workflow.md
+++ b/EnginePromptMestre/agents/workflow.md
@@ -6,6 +6,13 @@
 
 ---
 
+## ✅ Políticas P1–P6 (Obrigatórias)
+- Leia e aplique [`politicas.md`](./politicas.md) antes de executar qualquer etapa ou instrução compartilhada.
+- Assegure reuso verificado e âncoras claras em cada plano (P1, P2) e mantenha logs/diffs concisos (P3, P4).
+- Preserve modularidade dos artefatos distribuídos (P5) e baseie decisões no conhecimento oficial do projeto (P6).
+
+---
+
 ## VISÃO GERAL DO WORKFLOW
 
 O workflow é estruturado em **5 etapas sequenciais** (0→4), cada uma com agentes especializados, entregas obrigatórias e aprovações explícitas.


### PR DESCRIPTION
## Summary
- add a shared P1–P6 policy reference for all Engine Prompt Mestre agents
- embed the policy requirements across orchestrator, specialist, and workflow templates
- provide lightweight knowledge/analysis/plan/implementation helpers aligned with the policies

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130651a5348326a13d7335332cb1a1)